### PR TITLE
docs: update `ddev get` to `ddev add-on get` in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,14 +1,24 @@
 [![tests](https://github.com/mandrasch/ddev-addon-statamic-please/actions/workflows/tests.yml/badge.svg)](https://github.com/mandrasch/ddev-addon-statamic-please/actions/workflows/tests.yml) ![project is maintained](https://img.shields.io/maintenance/yes/2022.svg)
 
-DDEV addon for supporting statamics `please`-command. 
+DDEV addon for supporting statamics `please`-command.
 
-Install via:
+## Installation
 
-```bash
+For DDEV v1.23.5 or above run
+
+```sh
+ddev add-on get mandrasch/ddev-addon-statamic-please
+```
+
+For earlier versions of DDEV run
+
+```sh
 ddev get mandrasch/ddev-addon-statamic-please
 ```
 
-All it does is adding this custom command file to `.ddev/`:
+## Usage
+
+All it does is add this custom command file to `.ddev/`:
 
 https://github.com/mandrasch/ddev-statamic-please/blob/main/commands/web/please
 


### PR DESCRIPTION
In [DDEV 1.23.5](https://github.com/ddev/ddev/releases/tag/v1.23.5) the ddev get command was deprecated in favour of ddev add-on get.

This PR updates those references in the readme file. There may be some additional markdown improvements as well.

The changes were made manually, but the PR itself was automatically created - I'm doing over 100 of these. I apologise if its not 100% to the contributor standards required by this repo. Let me know if I need to change anything.